### PR TITLE
add `print_exe_name` option

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,5 +20,7 @@
         .bail = 0,
         // Enable executing lifecycle hooks such as BeforeAll and AfterAll.
         .lifecycle_hooks = true,
+        // Print the name of the test executable.
+        .print_exe_name = false,
     },
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,6 +9,7 @@ const Config = struct {
         rerun_each: u8 = 1,
         bail: u8 = 0,
         lifecycle_hooks: bool = true,
+        print_exe_name: bool = false,
     } = .{},
 };
 
@@ -123,6 +124,14 @@ pub fn main() !void {
         try c.blue().fmt("{}", .{leak_count}),
         try c.gray().fmt("({} total)", .{total_count}),
     });
+
+    if (config.print_exe_name) {
+        var arg_iter = try std.process.argsWithAllocator(allocator);
+        defer arg_iter.deinit();
+        if (arg_iter.next()) |exe_name| {
+            std.debug.print("{s} ", .{std.fs.path.basename(exe_name)});
+        }
+    }
 
     std.debug.print("{s} {s}\n", .{
         if (fail_count == 0 and leak_count == 0)


### PR DESCRIPTION
Adds an option to print the basename of the test executable.

This is useful when there are multiple test exes:
```
$ zig build test

8 passed, 0 failed, 0 skipped, 0 leaked (8 total)
bitjuggle ✓ Test suite passed (165.643us)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
containers ✓ Test suite passed (119.745us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
fs ✓ Test suite passed (67.088us)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
sdf ✓ Test suite passed (87.296us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
sdf_builder_test ✓ Test suite passed (124.585us)

2 passed, 0 failed, 0 skipped, 0 leaked (2 total)
uuid ✓ Test suite passed (620.126us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
kernel_log_wrapper_test ✓ Test suite passed (83.857us)

1 passed, 0 failed, 0 skipped, 0 leaked (1 total)
core ✓ Test suite passed (82.547us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
limine ✓ Test suite passed (80.967us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
image_builder_test ✓ Test suite passed (52.308us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
arm ✓ Test suite passed (8.191ms)

8 passed, 0 failed, 0 skipped, 0 leaked (8 total)
bitjuggle ✓ Test suite passed (5.798ms)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
fs ✓ Test suite passed (4.523ms)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
sdf ✓ Test suite passed (6.473ms)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
containers ✓ Test suite passed (8.553ms)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
limine ✓ Test suite passed (4.145ms)

2 passed, 0 failed, 0 skipped, 0 leaked (2 total)
uuid ✓ Test suite passed (14.408ms)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
riscv ✓ Test suite passed (3.793ms)

8 passed, 0 failed, 0 skipped, 0 leaked (8 total)
bitjuggle ✓ Test suite passed (5.36ms)

1 passed, 0 failed, 0 skipped, 0 leaked (1 total)
core ✓ Test suite passed (5.135ms)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
sdf ✓ Test suite passed (5.903ms)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
x64 ✓ Test suite passed (40.168us)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
fs ✓ Test suite passed (3.728ms)

1 passed, 0 failed, 0 skipped, 0 leaked (1 total)
core ✓ Test suite passed (4.001ms)

2 passed, 0 failed, 0 skipped, 0 leaked (2 total)
uuid ✓ Test suite passed (11.852ms)

0 passed, 0 failed, 0 skipped, 0 leaked (0 total)
limine ✓ Test suite passed (3.996ms)

3 passed, 0 failed, 0 skipped, 0 leaked (3 total)
containers ✓ Test suite passed (6.752ms)
```